### PR TITLE
feat: listen on new port

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@nuxt/screen",
   "private": true,
-  "license": "MIT",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/nuxt/screens.git"
   },
+  "license": "MIT",
   "workspaces": [
     "packages/*"
   ],
   "scripts": {
-    "lint": "eslint .",
     "build": "yarn workspaces run poi --prod",
-    "prepublish": "yarn build && yarn lint",
     "bump": "yarn lerna version --yes --no-push",
+    "lint": "eslint .",
+    "prepublish": "yarn build && yarn lint",
     "release": "yarn bump && git push --follow-tags && npm publish"
   },
   "devDependencies": {

--- a/packages/loading/app/app.vue
+++ b/packages/loading/app/app.vue
@@ -110,7 +110,7 @@ export default {
     }
 
     this.onData(window.$STATE)
-    this.sseConnect(`${this.baseURL}_loading/sse`)
+    this.sseConnect(`${this.baseURL}/sse`)
     this.setTimeout()
   },
 
@@ -135,7 +135,7 @@ export default {
       this.clearTimeout()
 
       try {
-        const data = await fetch(`${this.baseURL}_loading/json`).then(res => res.json())
+        const data = await fetch(`${this.baseURL}/json`).then(res => res.json())
         this.onData(data)
       } catch (e) {
         this.logError(e)

--- a/packages/loading/lib/loading.js
+++ b/packages/loading/lib/loading.js
@@ -2,6 +2,7 @@ const { resolve } = require('path')
 const connect = require('connect')
 const serveStatic = require('serve-static')
 const fs = require('fs-extra')
+const getPort = require('get-port-plz')
 const { json, end, header } = require('node-res')
 
 const { parseStack } = require('./utils/error')
@@ -51,16 +52,16 @@ class LoadingUI {
     await this._listen()
   }
 
-  _listen () {
+  async _listen () {
+    if (this._server) {
+      return
+    }
+
+    const port = await getPort({ random: true, name: 'nuxt_loading' })
+
     return new Promise((resolve, reject) => {
-      if (this._server) {
-        return resolve()
-      }
-      this._server = this.app.listen(0, (err) => {
-        if (err) {
-          return reject(err)
-        }
-        const { port } = this._server.address()
+      this._server = this.app.listen(port, (err) => {
+        if (err) { return reject(err) }
         this.baseURL = `http://localhost:${port}`
         resolve()
       })

--- a/packages/loading/lib/loading.js
+++ b/packages/loading/lib/loading.js
@@ -26,6 +26,13 @@ class LoadingUI {
   }
 
   async init () {
+    // Fix CORS and prefix issue
+    this.app.use((req, res, next) => {
+      req.url = req.url.replace('/_loading', '')
+      res.setHeader('Access-Control-Allow-Origin', '*')
+      next()
+    })
+
     // Subscribe to SSR channel
     this.app.use('/sse', (req, res) => this.sse.subscribe(req, res))
 
@@ -40,6 +47,19 @@ class LoadingUI {
     const indexPath = resolve(distPath, 'index.html')
     this.indexTemplate = await fs.readFile(indexPath, 'utf-8')
     this.app.use('/', this.serveIndex)
+  }
+
+  listen () {
+    return new Promise((resolve, reject) => {
+      const server = this.app.listen(0, (err) => {
+        if (err) {
+          return reject(err)
+        }
+        const { port } = server.address()
+        this.baseURL = `http://localhost:${port}/`
+        resolve()
+      })
+    })
   }
 
   get state () {

--- a/packages/loading/lib/module.js
+++ b/packages/loading/lib/module.js
@@ -3,15 +3,13 @@ module.exports = async function NuxtLoadingScreen () {
     return
   }
   const LoadingUI = require('./loading')
-
-  const baseURL = this.options.router.base
-  const loading = new LoadingUI({ baseURL })
+  const loading = new LoadingUI()
   await loading.init()
-  await loading.listen()
 
-  this.addServerMiddleware({
-    path: '/_loading', // baseURL will be prepended by nuxt for middleware
-    handler: loading.app
+  this.nuxt.options._loadingScreenBaseURL = loading.baseURL
+
+  this.nuxt.hook('close', async () => {
+    await loading.close()
   })
 
   this.nuxt.hook('bundler:progress', (states) => {

--- a/packages/loading/lib/module.js
+++ b/packages/loading/lib/module.js
@@ -7,6 +7,7 @@ module.exports = async function NuxtLoadingScreen () {
   const baseURL = this.options.router.base
   const loading = new LoadingUI({ baseURL })
   await loading.init()
+  await loading.listen()
 
   this.addServerMiddleware({
     path: '/_loading', // baseURL will be prepended by nuxt for middleware

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -3,15 +3,15 @@
   "version": "1.2.0",
   "repository": "nuxt/loading-screen",
   "license": "MIT",
+  "main": "lib/module.js",
   "files": [
     "lib",
     "app-dist"
   ],
-  "main": "lib/module.js",
   "dependencies": {
     "connect": "^3.7.0",
     "fs-extra": "^8.1.0",
-    "get-port-plz": "^0.0.4",
+    "get-port-plz": "^0.0.6",
     "node-res": "^5.0.1",
     "serve-static": "^1.14.1"
   }

--- a/packages/loading/package.json
+++ b/packages/loading/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "connect": "^3.7.0",
     "fs-extra": "^8.1.0",
+    "get-port-plz": "^0.0.4",
     "node-res": "^5.0.1",
     "serve-static": "^1.14.1"
   }

--- a/packages/loading/poi.config.js
+++ b/packages/loading/poi.config.js
@@ -1,7 +1,7 @@
 module.exports = {
   entry: './app/index.js',
   output: {
-    publicUrl: '{BASE_URL}_loading/',
+    publicUrl: '{BASE_URL}',
     dir: 'app-dist',
     html: {
       template: 'app/index.html',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4924,10 +4924,10 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
-fs-memo@^0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/fs-memo/-/fs-memo-0.0.5.tgz#3c97875a2f1c9c337c9681b303c850e887f4faa4"
-  integrity sha512-gEzYHnC2mUI5i2ATdDY6XBNA2VRxSXz5G89TsyV+P33dyDqn+1QHpTX0ewWLDyMekHrO6SFu1UiFGmc8rm7zzQ==
+fs-memo@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/fs-memo/-/fs-memo-0.0.6.tgz#c447905dbc7f7f75e8bd4b914dfb3be10b462967"
+  integrity sha512-vJVm33iM7BiTitGV+i4zwTkD92NQxv1yCClFT5SiAnRX1nGtXgodKm3wJ3Rl5dNPqwgBhKtBAf0hq0m2Iid5fw==
 
 fs-minipass@^1.2.5:
   version "1.2.7"
@@ -5016,12 +5016,12 @@ get-pkg-repo@^1.0.0:
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
 
-get-port-plz@^0.0.4:
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/get-port-plz/-/get-port-plz-0.0.4.tgz#7f96fb3e903377c45d02d38f58ddc66b615a55ec"
-  integrity sha512-WBFg1mXBk0VTVPEwngJIV2vwbqmTAxWxcUnh/v1/VxQtiwQqIfI7AdO1e7F4cc7ogjkMv3EOwsYj/49sneZtmg==
+get-port-plz@^0.0.6:
+  version "0.0.6"
+  resolved "https://registry.yarnpkg.com/get-port-plz/-/get-port-plz-0.0.6.tgz#adc7f0b5407ba04ba0984bdb206ee1af9ffba1a3"
+  integrity sha512-92HZTnhRPo5Mhpw67/+9b3m+/GjWLFQGJL3sE3H9jdjy0CvuL9MFr4jQHymS0nSFWeEQmJ75/RG99uIVPo7YPQ==
   dependencies:
-    fs-memo "^0.0.5"
+    fs-memo "^0.0.6"
 
 get-port@^4.2.0:
   version "4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4924,6 +4924,11 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-memo@^0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/fs-memo/-/fs-memo-0.0.5.tgz#3c97875a2f1c9c337c9681b303c850e887f4faa4"
+  integrity sha512-gEzYHnC2mUI5i2ATdDY6XBNA2VRxSXz5G89TsyV+P33dyDqn+1QHpTX0ewWLDyMekHrO6SFu1UiFGmc8rm7zzQ==
+
 fs-minipass@^1.2.5:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -5010,6 +5015,13 @@ get-pkg-repo@^1.0.0:
     normalize-package-data "^2.3.0"
     parse-github-repo-url "^1.3.0"
     through2 "^2.0.0"
+
+get-port-plz@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/get-port-plz/-/get-port-plz-0.0.4.tgz#7f96fb3e903377c45d02d38f58ddc66b615a55ec"
+  integrity sha512-WBFg1mXBk0VTVPEwngJIV2vwbqmTAxWxcUnh/v1/VxQtiwQqIfI7AdO1e7F4cc7ogjkMv3EOwsYj/49sneZtmg==
+  dependencies:
+    fs-memo "^0.0.5"
 
 get-port@^4.2.0:
   version "4.2.0"


### PR DESCRIPTION
We were using WS before 1.x [src](https://github.com/nuxt/screens/blob/v0.5.2/lib/loading.js) but migrated to SSE because of two reasons:

1. Browser compatibility (same issue as webpack HMR)
2. Programmatic usage and custom servers

But it started another issue (nuxt/nuxt.js#6442) as of connection limitations.

This PR resolves connection limit issue (so in the worst case, loading-indicator popup will not work until reload). After this PR we can add optional WS support as well because the server is separated so we don't get (2) issue and as is optional we won't get (1) issue.

As this is a breaking change for nuxt, we need to release as a major with some changes to nuxt for usage. (nuxt/nuxt.js#7286)
