### PR TITLE
fix(sse): don't set `connection` header if on http/2

### DIFF
--- a/packages/loading/lib/sse.js
+++ b/packages/loading/lib/sse.js
@@ -13,7 +13,10 @@ class SSE {
     status(res, 200)
     header(res, 'Content-Type', 'text/event-stream')
     header(res, 'Cache-Control', 'no-cache')
-    header(res, 'Connection', 'keep-alive')
+
+    if (req.httpVersion !== '2.0') {
+      header(res, 'Connection', 'keep-alive')
+    }
 
     this.subscriptions.add(res)
     res.on('close', () => this.subscriptions.delete(res))


### PR DESCRIPTION
* "Connection-specific header fields such as Connection and Keep-Alive are prohibited in HTTP/2." - https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Connection